### PR TITLE
Audio playing in every dialogue issue.

### DIFF
--- a/Assets/InkLibrary.asset
+++ b/Assets/InkLibrary.asset
@@ -26,11 +26,11 @@ MonoBehaviour:
     jsonAssetPath: {fileID: 0}
     jsonAsset: {fileID: 0}
   - compileAutomatically: 0
-    inkAsset: {fileID: 102900000, guid: f7a296d6dfa7942f6bd8562d33d64a02, type: 3}
+    inkAsset: {fileID: 102900000, guid: ac4767a32d32644e5834f1a028698894, type: 3}
     jsonAssetPath: {fileID: 0}
     jsonAsset: {fileID: 0}
   - compileAutomatically: 0
-    inkAsset: {fileID: 102900000, guid: ac4767a32d32644e5834f1a028698894, type: 3}
+    inkAsset: {fileID: 102900000, guid: f7a296d6dfa7942f6bd8562d33d64a02, type: 3}
     jsonAssetPath: {fileID: 0}
     jsonAsset: {fileID: 0}
   pendingCompilationStack: []

--- a/Assets/Level/Prefabs/UI/UICanvas.prefab
+++ b/Assets/Level/Prefabs/UI/UICanvas.prefab
@@ -4678,7 +4678,7 @@ AudioSource:
   serializedVersion: 4
   OutputAudioMixerGroup: {fileID: 0}
   m_audioClip: {fileID: 0}
-  m_PlayOnAwake: 1
+  m_PlayOnAwake: 0
   m_Volume: 0.25
   m_Pitch: 1
   Loop: 0

--- a/Packages/packages-lock.json
+++ b/Packages/packages-lock.json
@@ -94,7 +94,7 @@
       "depth": 0,
       "source": "registry",
       "dependencies": {
-        "com.unity.test-framework": "1.1.3"
+        "com.unity.test-framework": "1.1.1"
       },
       "url": "https://packages.unity.com"
     },


### PR DESCRIPTION
In Audio Source these is a setting called Play on Awake.  Originally the audio clip isn't set, so it doesn't play anything when dialogue opens, but when you get the quest, it sets the audio to the quest play.  After that, every time the dialogue is turned on, it plays the clip.  Simply turning this setting off, prevents it from playing until specifically told to in scripts.